### PR TITLE
Delete 3.1

### DIFF
--- a/CPM/Collaborative-Mark-Policy-draft.md
+++ b/CPM/Collaborative-Mark-Policy-draft.md
@@ -69,9 +69,6 @@ Regardless of whether you use a notice or a trademark symbol to identify your us
 
 ## 3. When you may use the Community marks without asking us 
 
-### 3.1. Use of trademarks on Community projects
-You may use and remix the Community marks on the Community projects as you please.
-
 ### 3.2. Community-focused events
 You may use the trademarks for events that promote our mission and are intended to be predominantly attended by Community community members. These are events like `[insert relevant events attended predominantly by community members]`. 
 


### PR DESCRIPTION
Suggest deleting 3.1. "You may use and remix the Community marks on the Community projects as you please." If the "project" is something distributable, like software, then you are telling people it is ok to modify product and then use a bastardized trademark on it. That is harmful to the brand and possibly an express naked license. I don't know in what context this provision makes sense except for something non-distributable, like Wikipedia.
