### PR TITLE
remove redundant "Community"

### DIFF
--- a/CPM/Collaborative-Mark-Policy-draft.md
+++ b/CPM/Collaborative-Mark-Policy-draft.md
@@ -70,7 +70,7 @@ Regardless of whether you use a notice or a trademark symbol to identify your us
 ## 3. When you may use the Community marks without asking us 
 
 ### 3.2. Community-focused events
-You may use the trademarks for events that promote our mission and are intended to be predominantly attended by Community community members. These are events like `[insert relevant events attended predominantly by community members]`. 
+You may use the trademarks for events that promote our mission and are intended to be predominantly attended by community members. These are events like `[insert relevant events attended predominantly by community members]`. 
 
 For example, you can put the `[insert name of community’s logo] on banners and posters at an [relevant event attended predominantly by community members]` you've organized. 
 


### PR DESCRIPTION
"Community community members" seems somewhat (though admittedly not perfectly) redundant, recommend removing.
