### PR TITLE
Remove references to "forms" in Sec. 7.1

### DIFF
--- a/CPM/Collaborative-Mark-Policy-draft.md
+++ b/CPM/Collaborative-Mark-Policy-draft.md
@@ -217,7 +217,7 @@ We will give notice of proposed revisions on the Community projects and in an em
 #### 7.1.2.
 For minor changes or changes required by law, when possible we will provide three days’ notice to `[relevant community mailing list]`.  Minor changes include language fixes, administrative changes, or corrections of inaccurate statements.
 
-This section does not apply to the user-friendly summary, the FAQs, the purpose statement for the trademark policy, the trademark request form, and the violation reporting form. They are not part of this trademark policy and can always be revised without notice.
+This section does not apply to the user-friendly summary, the FAQs, or the purpose statement. They are not part of this trademark policy and can always be revised without notice.
 
 ### 7.2. `[If relevant: Translation of the trademark policy`
 `If some term in a translation of this trademark policy is inconsistent with the original English version of this policy, you should follow the original English version.]`


### PR DESCRIPTION
Sec. 7.1 refers to forms which are not part of this template, so I removed those. Also removed redundant "for the trademark policy" from "the purpose statement", since there is no other purpose statement this would apply to.
