### PR TITLE
Globalize nominative use language

### DIFF
--- a/CPM/Collaborative-Mark-Policy-draft.md
+++ b/CPM/Collaborative-Mark-Policy-draft.md
@@ -145,7 +145,7 @@ You need a trademark license if you plan to host a public event or a conference 
 When you get a trademark license, it will only apply to the specific event in your request. You will need to apply for a new license if you want to host another event. 
 
 ### 4.4. Publications
-You need a trademark license if you want to use a Community mark in a publication in a way that is not fair or nominative use under U.S. trademark law or other applicable foreign laws.
+You need a trademark license if you want to use a Community mark in a publication in a way that is not fair, nominative, or referential use under applicable law.
 
 [You should include the following information when requesting a license to use our marks in a publication.]                                                                                                  
  1. What is the proposed title of the publication?


### PR DESCRIPTION
This phrase was somewhat US-centric, which makes sense for WMF but not for the template. This change:
1. Removes the reference to US law; and
2. Adds a reference to "referential" use, which is the preferred nomenclature in the EU (see, e.g., INTA on EU relevant statutory provisions: http://www.inta.org/INTABulletin/Pages/EU_TM_Reform_3_7022.aspx )

This is not perfect, as the caselaw in the EU is not as favorable to third parties as in the US, but Article 12 of the harmonized EU regulation does appear to have similar intent as US nominative fair use.

If we wanted to be more precise, one might drop "fair" here (it isn't terribly well-defined in US trademark law) and simply stick to nominative/referential. But that might be confusing to non-legal readers.