### PR TITLE
fix section numbering in 4.3 [cosmetic]

### DIFF
--- a/CPM/Collaborative-Mark-Policy-draft.md
+++ b/CPM/Collaborative-Mark-Policy-draft.md
@@ -134,13 +134,13 @@ You need permission to register or use a domain name that contains a Community m
 You need a trademark license if you plan to host a public event or a conference that uses a Community mark. 
 
 [You should include the following information when requesting a license to use our marks in an event.]                                                                                                  
-1. What is the proposed title of the event?
-2. Who is hosting, sponsoring, or coordinating the event? 
-3. Include contact information (and Community username if relevant) for the person organizing the event.
-4. Is the event organized for community members?
-5. What is the topic of the event?
-6. The location, date, and duration of the event.
-7. Include handouts, examples, mockups, or other descriptions of the proposed use.
+ 1. What is the proposed title of the event?
+ 2. Who is hosting, sponsoring, or coordinating the event? 
+ 3. Include contact information (and Community username if relevant) for the person organizing the event.
+ 4. Is the event organized for community members?
+ 5. What is the topic of the event?
+ 6. The location, date, and duration of the event.
+ 7. Include handouts, examples, mockups, or other descriptions of the proposed use.
 
 When you get a trademark license, it will only apply to the specific event in your request. You will need to apply for a new license if you want to host another event. 
 


### PR DESCRIPTION
Sec. 4.3 lacked spaces before the numbers in the example requests, so it did not parallel Sec. 4.4 or 4.5 stylistically and looked messy when reading it. This pull request fixes that. 